### PR TITLE
fix: Use trailing slash to force HTTPS for FlameScans

### DIFF
--- a/src/runners/flamescans/index.ts
+++ b/src/runners/flamescans/index.ts
@@ -15,7 +15,7 @@ class Template extends MangaThemesiaTemplate {
   lang = "en_us";
   name = "Flame Comics";
 
-  protected mangaUrlDirectory = "/series";
+  protected mangaUrlDirectory = "/series/";
 }
 
 export const Target = new TachiBuilder(info, Template);

--- a/src/runners/flamescans/index.ts
+++ b/src/runners/flamescans/index.ts
@@ -6,7 +6,7 @@ const info: RunnerInfo = {
   id: "flamecomics",
   name: "Flame Comics",
   thumbnail: "flamescans.png",
-  version: 0.2,
+  version: 0.3,
   website: "https://flamecomics.com",
 };
 

--- a/src/template/mangathemesia/index.ts
+++ b/src/template/mangathemesia/index.ts
@@ -12,8 +12,8 @@ import { CheerioAPI } from "cheerio";
 import moment from "moment";
 
 export abstract class MangaThemesiaTemplate extends TachiParsedHttpSource {
-  protected mangaUrlDirectory = "/manga";
-  protected projectPageString = "/project";
+  protected mangaUrlDirectory = "/manga/";
+  protected projectPageString = "/project/";
   protected searchQueryKey = "title";
   protected dateFormat = "MMMM dd, yyyy";
   supportsLatest = true;


### PR DESCRIPTION
same fix as was done for the nepnep extension