### PR TITLE
Fix asurascans

### DIFF
--- a/src/runners/asurascans/index.ts
+++ b/src/runners/asurascans/index.ts
@@ -14,7 +14,7 @@ import { load } from "cheerio";
 const info: RunnerInfo = {
   id: "asurascans",
   name: "Asura Scans",
-  version: 0.1,
+  version: 0.2,
   thumbnail: "asurascan.png",
 };
 

--- a/src/runners/asurascans/template.ts
+++ b/src/runners/asurascans/template.ts
@@ -8,6 +8,8 @@ export class Template extends MangaThemesiaTemplate {
   lang = "en";
   name = "Asura Scans";
 
+  dateFormat = "MMMM DD, yyyy";
+
   seriesDescriptionSelector =
     "div.desc p, div.entry-content p, div[itemprop=description]:not(:has(p))";
   seriesArtistSelector =

--- a/src/template/tachiyomi/ChapterRecognition.ts
+++ b/src/template/tachiyomi/ChapterRecognition.ts
@@ -2,6 +2,7 @@ export class ChapterRecognition {
   private readonly NUMBER_PATTERN: string = "([0-9]+)(\\.[0-9]+)?(\\.?[a-z]+)?";
   private basic = new RegExp(`(ch\\.) *${this.NUMBER_PATTERN}`, "i");
   private number = new RegExp(this.NUMBER_PATTERN);
+  private preview = /preview/i;
   private unwanted = /\b(?:v|ver|vol|version|volume|season|s)[^a-z]?[0-9]+/;
   private unwantedWhiteSpace = /\s(?=extra|special|omake)/;
 
@@ -32,6 +33,11 @@ export class ChapterRecognition {
     const numberMatch = name.match(this.number);
     if (numberMatch) {
       return this.getChapterNumberFromMatch(numberMatch);
+    }
+
+    const previewMatch = name.match(this.preview);
+    if (previewMatch) {
+      return 0;
     }
 
     return chapterNumber !== undefined

--- a/src/tests/asurascans.test.ts
+++ b/src/tests/asurascans.test.ts
@@ -36,7 +36,7 @@ describe("Asura Scans Tests", () => {
       expect(data.results.length).toBeGreaterThan(1);
     });
   });
-  const id = "/manga/2122552102-return-of-the-unrivaled-spear-knight/";
+  const id = "/manga/4622438374-player-who-returned-10000-years-later/";
 
   test("Profile", async () => {
     const content = await source.getContent(id);
@@ -51,7 +51,7 @@ describe("Asura Scans Tests", () => {
 
   test("Reader", async () => {
     const chapterId =
-      "/2122552102-return-of-the-unrivaled-spear-knight-chapter-110/";
+      "/1398222385-player-who-returned-10000-years-later-chapter-1/";
     const data = await source.getChapterData(id, chapterId);
     expect(ChapterDataSchema.parse(data)).toEqual(expect.any(Object));
   });


### PR DESCRIPTION
* Uses `MMMM DD, yyyy` to parse date correctly, was dropping day of the month with `dd` specifier
* Update chapter recognition to treat "Chapter Preview" as chap 0
* Fixes unit test which was using a dropped manga